### PR TITLE
ci: initial circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ version: 2
       steps:
         - checkout
         - setup_remote_docker
+        - run: npm run release:validate
         - run: npm run docker:build:release
         - run: npm run docker:push:release
 
@@ -51,6 +52,6 @@ workflows:
             - test
           filters:
             tags:
-              only: /\d\.\d\.\d/
+              only: /.*/ # allow anything because tag syntax is validated as part of validate-release.sh
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+version: 2
+  jobs:
+    test:
+      docker:
+        # Node 8 LTS
+        - image: circleci/node:carbon
+      steps:
+        - checkout
+        - run: npm install
+        - run: npm run lint
+        - run: npm test
+        - run: npm run build
+
+    docker_push_master:
+      docker:
+        # Node 8 LTS
+        - image: circleci/node:carbon
+      steps:
+        - checkout
+        - setup_remote_docker
+        - run: npm run docker:build
+        - run: npm run docker:push
+
+    docker_push_release:
+      docker:
+        # Node 8 LTS
+        - image: circleci/node:carbon
+      steps:
+        - checkout
+        - setup_remote_docker
+        - run: npm run docker:build:release
+        - run: npm run docker:push:release
+
+workflows:
+  version: 2
+  build_and_push:
+    jobs:
+      - test:
+          filters:
+            tags:
+              only: /.*/
+      - docker_push_master:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master
+      - docker_push_release:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /\d\.\d\.\d/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,36 +1,36 @@
 version: 2
-  jobs:
-    test:
-      docker:
-        # Node 8 LTS
-        - image: circleci/node:carbon
-      steps:
-        - checkout
-        - run: npm install
-        - run: npm run lint
-        - run: npm test
-        - run: npm run build
+jobs:
+  test:
+    docker:
+      # Node 8 LTS
+      - image: circleci/node:carbon
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build
 
-    docker_push_master:
-      docker:
-        # Node 8 LTS
-        - image: circleci/node:carbon
-      steps:
-        - checkout
-        - setup_remote_docker
-        - run: npm run docker:build
-        - run: npm run docker:push
+  docker_push_master:
+    docker:
+      # Node 8 LTS
+      - image: circleci/node:carbon
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: npm run docker:build
+      - run: npm run docker:push
 
-    docker_push_release:
-      docker:
-        # Node 8 LTS
-        - image: circleci/node:carbon
-      steps:
-        - checkout
-        - setup_remote_docker
-        - run: npm run release:validate
-        - run: npm run docker:build:release
-        - run: npm run docker:push:release
+  docker_push_release:
+    docker:
+      # Node 8 LTS
+      - image: circleci/node:carbon
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: npm run release:validate
+      - run: npm run docker:build:release
+      - run: npm run docker:push:release
 
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "echo 'TODO: setup linting'"
   },
   "devDependencies": {
     "redux": "^4.0.0"


### PR DESCRIPTION
Hey folks,

just a little gift for you guys: a sample CircleCI config also with release stuff in place.

It's a skeleton where the actual steps such as testing, linting, docker builds and releases have not been implemented. However this config should work out of the box and you can think of it as an API/Interface that can be implemented in any way you'd like. As an example, we are using [Standard](https://standardjs.com/) for linting, but you guys can use whatever you'd like as long as you wire it up to `npm run lint` then you'll get it for free in CI. Hope that makes sense :)

Please let me know what you think.

I also have a very similar PR open against the data-sync-server repo which you can see here: https://github.com/aerogear/data-sync-server/pull/3