### PR TITLE
Fixes Lint checks in CI/CD

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/aerogear/data-sync-ui",
   "scripts": {
-    "lint": "eslint server test ui webpack.config.js --fix",
+    "lint": "eslint server test ui webpack.config.js",
+    "lint:fix": "eslint server test ui webpack.config.js --fix",
     "server": "webpack --mode development && nodemon --watch ui --exec babel-node server/index.js",
     "build": "webpack --mode production && babel server --out-dir dist/",
     "clean": "rm -rf dist public/js/bundle.js node_modules",


### PR DESCRIPTION
I realized the lint step in CircleCI was wrong, to correctly check code format the script should not be `--fix` flagged. I added a new script for local development.