### PR TITLE
use ilike only where its supported

### DIFF
--- a/server/gql/schema.js
+++ b/server/gql/schema.js
@@ -1,6 +1,6 @@
 const { buildSchema } = require("graphql");
 const { info } = require("../logger");
-const { dataSource, database } = require("../models");
+const { dataSource, database, supportsiLike } = require("../models");
 
 const Schema = buildSchema(`
     enum DataSourceType {
@@ -36,7 +36,8 @@ const createDataSource = ({ name, type, config }) => {
 const listDataSources = ({ name }) => {
     info("listDataSources request");
     if (name) {
-        return dataSource.findAll({ where: { name: { [database.Op.iLike]: `%${name}%` } } });
+        const operator = supportsiLike() ? database.Op.iLike : database.Op.like;
+        return dataSource.findAll({ where: { name: { [operator]: `%${name}%` } } });
     }
     return dataSource.findAll();
 };

--- a/server/models/database.js
+++ b/server/models/database.js
@@ -1,6 +1,10 @@
 const { Sequelize } = require("sequelize");
 const { postgresConfig } = require("../config");
 
+exports.supportsiLike = function() {
+    return process.env.NODE_ENV !== "test";
+};
+
 exports.createDatabase = function () {
     if (process.env.NODE_ENV === "test") {
         return new Sequelize("sqlite://:memory:", null, null, { dialect: "sqlite" });

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,5 +1,5 @@
 const { Sequelize } = require("sequelize");
-const { createDatabase } = require("./database");
+const { createDatabase, supportsiLike } = require("./database");
 const DataSourceModel = require("./dataSource");
 const SchemaModel = require("./schema");
 
@@ -13,5 +13,6 @@ module.exports = {
     database,
     dataSource,
     sync,
-    schema
+    schema,
+    supportsiLike
 };


### PR DESCRIPTION
Sequelize only supports `iLike` with Postgres. We use Sqlite for our tests. While this is not critical i thought it would be a good idea to have a fallback for cases where iLike is not supported.