### PR TITLE
reset data source

### DIFF
--- a/ui/components/data-sources/DataSourcesContainer.js
+++ b/ui/components/data-sources/DataSourcesContainer.js
@@ -63,14 +63,16 @@ class DataSourcesContainer extends Component {
                     visible={showAddModal}
                 />
                 <EditDataSourceDialog
-                    onClose={() => this.setState({ showEditModal: false, selectedDataSource: null })}
+                    onClose={() => this.setState({ showEditModal: false,
+                        selectedDataSource: null })}
                     dataSource={selectedDataSource}
                     visible={showEditModal}
                 />
                 <DeleteDataSourceDialog
                     showModal={showDeleteModal}
                     dataSource={selectedDataSource}
-                    onClose={() => this.setState({ showDeleteModal: false, selectedDataSource: null })}
+                    onClose={() => this.setState({ showDeleteModal: false,
+                        selectedDataSource: null })}
                 />
                 <CommonToolbar
                     buttons={this.getToolbarButtons()}

--- a/ui/components/data-sources/DataSourcesContainer.js
+++ b/ui/components/data-sources/DataSourcesContainer.js
@@ -63,14 +63,14 @@ class DataSourcesContainer extends Component {
                     visible={showAddModal}
                 />
                 <EditDataSourceDialog
-                    onClose={() => this.setState({ showEditModal: false })}
+                    onClose={() => this.setState({ showEditModal: false, selectedDataSource: null })}
                     dataSource={selectedDataSource}
                     visible={showEditModal}
                 />
                 <DeleteDataSourceDialog
                     showModal={showDeleteModal}
                     dataSource={selectedDataSource}
-                    onClose={() => this.setState({ showDeleteModal: false })}
+                    onClose={() => this.setState({ showDeleteModal: false, selectedDataSource: null })}
                 />
                 <CommonToolbar
                     buttons={this.getToolbarButtons()}

--- a/ui/components/data-sources/EditDataSourceDialog.js
+++ b/ui/components/data-sources/EditDataSourceDialog.js
@@ -25,7 +25,7 @@ class EditDataSourceDialog extends BaseDataSourceDialog {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.dataSource !== prevProps.dataSource) {
+        if (this.props.dataSource && this.props.dataSource !== prevProps.dataSource) {
             const { id, name, type } = this.props.dataSource;
             const config = JSON.parse(this.props.dataSource.config);
             this.setState({


### PR DESCRIPTION
Fix an error where the state of the dialog was modified even if you clicked `Cancel`.  Verification steps:

1. Create a data source
1. Click `Edit Data Source`, delete the name but click `Cancel`
1. Click `Edit Data Source` again. The name field should be filled.