### PR TITLE
fix console warnings about validation state

### DIFF
--- a/ui/components/data-sources/AddDataSourceDialog.js
+++ b/ui/components/data-sources/AddDataSourceDialog.js
@@ -15,7 +15,7 @@ const INITIAL_STATE = {
     validations: {
         name: null,
         type: "warning",
-        options: "ok"
+        options: "success"
     }
 };
 

--- a/ui/components/data-sources/BaseDataSourceDialog.js
+++ b/ui/components/data-sources/BaseDataSourceDialog.js
@@ -25,7 +25,7 @@ class BaseDataSourceDialog extends Component {
     }
 
     onNameChange(name) {
-        const nameValidation = name && name.length < 255 ? "ok" : "error";
+        const nameValidation = name && name.length < 255 ? "success" : "error";
 
         const { validations } = this.state;
         const newValidations = { ...validations, name: nameValidation };
@@ -34,7 +34,8 @@ class BaseDataSourceDialog extends Component {
     }
 
     onTypeChange(type) {
-        const typeValidation = DataSourceType[type] ? "ok" : "error";
+        let typeValidation = DataSourceType[type] ? "success" : "error";
+        typeValidation = type === DataSourceType.InMemory ? "warning" : typeValidation;
 
         const { validations } = this.state;
         const newValidations = { ...validations, type: typeValidation };
@@ -46,7 +47,7 @@ class BaseDataSourceDialog extends Component {
         const { timestampData } = options;
         const optionsValidation = typeof timestampData === "boolean"
             // && further validations here
-            ? "ok" : "error";
+            ? "success" : "error";
 
         const { validations } = this.state;
         const newValidations = { ...validations, optionsValidation };

--- a/ui/components/data-sources/EditDataSourceDialog.js
+++ b/ui/components/data-sources/EditDataSourceDialog.js
@@ -11,9 +11,9 @@ const INITIAL_STATE = {
     options: null,
     err: "",
     validations: {
-        name: "ok",
-        type: "ok",
-        options: "ok"
+        name: "success",
+        type: "success",
+        options: "success"
     }
 };
 


### PR DESCRIPTION
Currently we get a big red warning in the browser console because `ok` is not a valid state:

```
Warning: Failed prop type: Invalid prop `validationState` of value `ok` supplied to `FormGroup`, expected one of ["success","warning","error",null]. in FormGroup (created by EditDataSourceDialog) in EditDataSourceDialog (created by Mutation) in Mutation (created by Apollo(EditDataSourceDialog)) in Apollo(EditDataSourceDialog) (created by DataSourcesContainer) in div (created by DataSourcesContainer) in DataSourcesContainer (created by App) in div (created by TabPane) in TabPane (created by App) in div (created by TabContent) in TabContent (created by App) in div (created by App) in TabContainer (created by Uncontrolled(TabContainer)) in Uncontrolled(TabContainer) (created by App) in div (created by App) in div (created by App) in App in ApolloProvider
```

If we dont want the colors (i don't mind them) we should fix them using CSS.