### PR TITLE
refetch filter query when data source is deleted

### DIFF
--- a/ui/components/data-sources/DataSourcesContainer.js
+++ b/ui/components/data-sources/DataSourcesContainer.js
@@ -71,6 +71,7 @@ class DataSourcesContainer extends Component {
                 <DeleteDataSourceDialog
                     showModal={showDeleteModal}
                     dataSource={selectedDataSource}
+                    filter={filter}
                     onClose={() => this.setState({ showDeleteModal: false,
                         selectedDataSource: null })}
                 />

--- a/ui/components/data-sources/DeleteDataSourceDialog.js
+++ b/ui/components/data-sources/DeleteDataSourceDialog.js
@@ -6,11 +6,15 @@ import { graphql } from "react-apollo";
 import DeleteDataSource from "../../graphql/DeleteDataSource.graphql";
 import GetDataSources from "../../graphql/GetDataSources.graphql";
 
-const DeleteDataSourceDialog = ({ showModal, dataSource, mutate, onClose }) => {
+const DeleteDataSourceDialog = ({ showModal, dataSource, filter, mutate, onClose }) => {
     const removeOneDatasource = dataSourceId => {
+        const { name } = filter;
         mutate({
             variables: { dataSourceId },
             refetchQueries: [{
+                query: GetDataSources,
+                variables: { name }
+            }, {
                 query: GetDataSources,
                 variables: { name: undefined }
             }]


### PR DESCRIPTION
Fixes the problem where the data sources list was not updated when a filter was applied and a data source was deleted. The problem seems to be the way Apollo caches queries: we need to refetch the query without a filter value separately.