### PR TITLE
fix: calculate height of schema editor

### DIFF
--- a/ui/components/schema/SchemaContainer.js
+++ b/ui/components/schema/SchemaContainer.js
@@ -19,22 +19,19 @@ class SchemaContainer extends Component {
     constructor(props) {
         super(props);
         this.state = INITIAL_STATE;
-        this.flexWrapper = null;
-
-        this.setflexWrapperRef = e => {
-            this.flexWrapper = e;
-        };
+        this.flexWrapper = React.createRef();
     }
 
     updateDimensions() {
         this.setState({
-            height: window.innerHeight - this.flexWrapper.getBoundingClientRect().top
+            height: window.innerHeight - this.flexWrapper.current.getBoundingClientRect().top
         });
     }
 
     componentDidUpdate() {
-        const currentHeight = this.flexWrapper.style.height;
-        const distanceFromTop = this.flexWrapper.getBoundingClientRect().top;
+        const flexWrapperElement = this.flexWrapper.current;
+        const currentHeight = flexWrapperElement.style.height;
+        const distanceFromTop = flexWrapperElement.getBoundingClientRect().top;
         if (currentHeight === "0px" && distanceFromTop !== 0) {
             this.updateDimensions();
         }
@@ -105,7 +102,11 @@ class SchemaContainer extends Component {
         return (
             <React.Fragment>
                 <CommonToolbar buttons={this.getToolbarButtons()} />
-                <div ref={this.setflexWrapperRef} className={style.flexWrapper} style={{ height: this.state.height }}>
+                <div
+                    ref={this.flexWrapper}
+                    className={style.flexWrapper}
+                    style={{ height: this.state.height }}
+                >
                     <div className={style.left}>
                         <CodeEditor
                             value={schema}

--- a/ui/components/schema/SchemaContainer.js
+++ b/ui/components/schema/SchemaContainer.js
@@ -9,7 +9,7 @@ import { StructureView } from "./StructureView";
 import style from "./schemaContainer.css";
 
 const INITIAL_STATE = {
-    height: "100%",
+    height: "0",
     schema: "",
     error: null
 };
@@ -19,16 +19,25 @@ class SchemaContainer extends Component {
     constructor(props) {
         super(props);
         this.state = INITIAL_STATE;
+        this.flexWrapper = null;
+
+        this.setflexWrapperRef = e => {
+            this.flexWrapper = e;
+        };
     }
 
     updateDimensions() {
         this.setState({
-            height: window.innerHeight - this.calculateHeaderHeight()
+            height: window.innerHeight - this.flexWrapper.getBoundingClientRect().top
         });
     }
 
-    componentWillMount() {
-        this.updateDimensions();
+    componentDidUpdate() {
+        const currentHeight = this.flexWrapper.style.height;
+        const distanceFromTop = this.flexWrapper.getBoundingClientRect().top;
+        if (currentHeight === "0px" && distanceFromTop !== 0) {
+            this.updateDimensions();
+        }
     }
 
     componentDidMount() {
@@ -37,11 +46,6 @@ class SchemaContainer extends Component {
 
     componentWillUnmount() {
         window.removeEventListener("resize", () => this.updateDimensions());
-    }
-
-    calculateHeaderHeight() {
-        // TODO: find SOME way to do this in pure CSS
-        return 206;
     }
 
     onSchemaChange(schema) {
@@ -101,7 +105,7 @@ class SchemaContainer extends Component {
         return (
             <React.Fragment>
                 <CommonToolbar buttons={this.getToolbarButtons()} />
-                <div className={style.flexWrapper} style={{ height: this.state.height }}>
+                <div ref={this.setflexWrapperRef} className={style.flexWrapper} style={{ height: this.state.height }}>
                     <div className={style.left}>
                         <CodeEditor
                             value={schema}


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-7596

* didn't find CSS solution for this issue - combining viewport height with overflow property could solve this issue, but it messes up **data sources** tab
* main problem with JS solution is that the distance of flexwrapper element from top can't be calculated before the element is displayed - this was the reason to use `componentDidUpdate` lifecycle method
* **this is just a suggestion of how we could fix that - feel free to (especially code owners) commit to this branch to make the code more elegant or even reject this**