### PR TITLE
fix: handle datasource config property as an JSON type

### DIFF
--- a/server/gql/schema.js
+++ b/server/gql/schema.js
@@ -15,9 +15,9 @@ const Schema = buildSchema(`
         getSchema(name: String!): Schema
     },
     type Mutation {
-        createDataSource(name: String!, type: DataSourceType!, config: String!): DataSource
+        createDataSource(name: String!, type: DataSourceType!, config: JSON!): DataSource
         deleteDataSource(id: Int!): DataSource
-        updateDataSource(id: Int!, name: String!, type: DataSourceType!, config: String!): DataSource
+        updateDataSource(id: Int!, name: String!, type: DataSourceType!, config: JSON!): DataSource
         updateSchema(id: Int!, schema: String!): Schema
         upsertResolver(
             id: Int
@@ -33,7 +33,7 @@ const Schema = buildSchema(`
         id: Int!
         name: String!
         type: DataSourceType! 
-        config: String!
+        config: JSON!
         resolvers: [Resolver]
     },
     type Schema {
@@ -52,6 +52,8 @@ const Schema = buildSchema(`
         responseMapping: String!
         DataSource: DataSource!
     }
+
+    scalar JSON
 `);
 
 const createDataSource = async ({ name, type, config }) => {

--- a/test/server/queries.js
+++ b/test/server/queries.js
@@ -1,11 +1,7 @@
 const queries = {
     CREATE_DATA_SOURCE_QUERY: ` 
-        mutation createDataSource {
-          createDataSource(
-            name: "TestDataSource"
-            type: Postgres
-            config: "config: test"
-          ) {
+        mutation createDataSource($name: String!, $type: DataSourceType!, $config: JSON!) {
+          createDataSource(name: $name, type: $type, config: $config) {
             id
             name
             type
@@ -39,7 +35,7 @@ const queries = {
       }
     }`,
     UPDATE_DATA_SOURCE_QUERY: `
-    mutation updateDataSource($id: Int!, $name: String!, $type: DataSourceType!, $config: String!) {
+    mutation updateDataSource($id: Int!, $name: String!, $type: DataSourceType!, $config: JSON!) {
       updateDataSource(id: $id, name: $name, type: $type, config: $config) {
         name
       }

--- a/test/server/tests.js
+++ b/test/server/tests.js
@@ -52,7 +52,7 @@ describe("Basic", () => {
         graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root, null, {
             name: "test",
             type: "Postgres",
-            config: {timestamps: true}
+            config: { timestamps: true }
         })
             .then(data => {
                 const { createDataSource: { id, name, type, config } } = data.data;
@@ -90,7 +90,7 @@ describe("Basic", () => {
         graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root, null, {
             name: "test",
             type: "Postgres",
-            config: {timestamps: true}
+            config: { timestamps: true }
         })
             .then(data => {
                 const { createDataSource: { id, name, type, config } } = data.data;
@@ -120,15 +120,15 @@ describe("Basic", () => {
         graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root, null, {
             name: "test",
             type: "Postgres",
-            config: {timestamps: true}
+            config: { timestamps: true }
         })
             .then(data => {
                 const { createDataSource: { id, name, type, config } } = data.data;
                 const msg = "unexpected value for: ";
-                const err = assert(data !== undefined, msg + "data")
-                    || assert(name === "test", msg + "name")
-                    || assert(type === "Postgres", msg + "type")
-                    || assert(typeof config === typeof {}, msg + "config");
+                const err = assert(data !== undefined, `${msg}data`)
+                    || assert(name === "test", `${msg}name`)
+                    || assert(type === "Postgres", `${msg}type`)
+                    || assert(typeof config === typeof {}, `${msg}config`);
                 if (err) {
                     throw err;
                 }
@@ -177,9 +177,9 @@ describe("Basic", () => {
             .then(schemaId => graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root, null, {
                 name: "test",
                 type: "Postgres",
-                config: {timestamps: true}
+                config: { timestamps: true }
             })
-            .then(data => ({ schemaId, data })))
+                .then(data => ({ schemaId, data })))
             .then(({ schemaId, data }) => {
                 const { createDataSource: { id } } = data.data;
                 return graphql(Schema, queries.UPSERT_RESOLVER, root, null, {

--- a/test/server/tests.js
+++ b/test/server/tests.js
@@ -49,14 +49,18 @@ describe("Basic", () => {
     });
 
     it("should delete a new data source", done => {
-        graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root)
+        graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root, null, {
+            name: "test",
+            type: "Postgres",
+            config: {timestamps: true}
+        })
             .then(data => {
                 const { createDataSource: { id, name, type, config } } = data.data;
                 const msg = "error creating datasource - problem with: ";
                 const err = assert(data !== undefined, `${msg}data is undefined`)
-                    || assert(name === "TestDataSource", msg + name)
+                    || assert(name === "test", msg + name)
                     || assert(type === "Postgres", msg + type)
-                    || assert(typeof config === typeof "", msg + config);
+                    || assert(typeof config === typeof {}, msg + config);
                 if (err) {
                     throw err;
                 }
@@ -83,14 +87,18 @@ describe("Basic", () => {
 
     it("should edit a new data source", done => {
         const NEW_NAME = "NEW DATA SOURCE NAME";
-        graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root)
+        graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root, null, {
+            name: "test",
+            type: "Postgres",
+            config: {timestamps: true}
+        })
             .then(data => {
                 const { createDataSource: { id, name, type, config } } = data.data;
                 const msg = "error creating editing datasource - problem with: ";
                 const err = assert(data !== undefined, msg + data)
-                    || assert(name === "TestDataSource", msg + name)
+                    || assert(name === "test", msg + name)
                     || assert(type === "Postgres", msg + type)
-                    || assert(typeof config === typeof "", msg + config);
+                    || assert(typeof config === typeof {}, msg + config);
                 if (err) {
                     throw err;
                 }
@@ -109,14 +117,18 @@ describe("Basic", () => {
 
     it("should edit a new data source", done => {
         const NEW_NAME = "NEW DATA SOURCE NAME";
-        graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root)
+        graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root, null, {
+            name: "test",
+            type: "Postgres",
+            config: {timestamps: true}
+        })
             .then(data => {
                 const { createDataSource: { id, name, type, config } } = data.data;
-                const msg = "error creating editing datasource - problem with: ";
-                const err = assert(data !== undefined, msg + data)
-                    || assert(name === "TestDataSource", msg + name)
-                    || assert(type === "Postgres", msg + type)
-                    || assert(typeof config === typeof "", msg + config);
+                const msg = "unexpected value for: ";
+                const err = assert(data !== undefined, msg + "data")
+                    || assert(name === "test", msg + "name")
+                    || assert(type === "Postgres", msg + "type")
+                    || assert(typeof config === typeof {}, msg + "config");
                 if (err) {
                     throw err;
                 }
@@ -162,8 +174,12 @@ describe("Basic", () => {
                 }
                 return id;
             })
-            .then(schemaId => graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root)
-                .then(data => ({ schemaId, data })))
+            .then(schemaId => graphql(Schema, queries.CREATE_DATA_SOURCE_QUERY, root, null, {
+                name: "test",
+                type: "Postgres",
+                config: {timestamps: true}
+            })
+            .then(data => ({ schemaId, data })))
             .then(({ schemaId, data }) => {
                 const { createDataSource: { id } } = data.data;
                 return graphql(Schema, queries.UPSERT_RESOLVER, root, null, {

--- a/ui/components/data-sources/AddDataSourceDialog.js
+++ b/ui/components/data-sources/AddDataSourceDialog.js
@@ -42,7 +42,7 @@ class AddDataSourceDialog extends BaseDataSourceDialog {
 
     createDataSource() {
         const { name, type, options } = this.state;
-        const config = JSON.stringify({ options });
+        const config = { options };
         const { filter } = this.props;
         return this.props.mutate({
             variables: { name, type, config },

--- a/ui/components/data-sources/EditDataSourceDialog.js
+++ b/ui/components/data-sources/EditDataSourceDialog.js
@@ -26,8 +26,7 @@ class EditDataSourceDialog extends BaseDataSourceDialog {
 
     componentDidUpdate(prevProps) {
         if (this.props.dataSource && this.props.dataSource !== prevProps.dataSource) {
-            const { id, name, type } = this.props.dataSource;
-            const config = JSON.parse(this.props.dataSource.config);
+            const { id, name, type, config } = this.props.dataSource;
             this.setState({
                 ...INITIAL_STATE,
                 id,

--- a/ui/graphql/CreateDataSource.graphql
+++ b/ui/graphql/CreateDataSource.graphql
@@ -1,4 +1,4 @@
-mutation createDataSource($name: String!, $type: DataSourceType!, $config: String!) {
+mutation createDataSource($name: String!, $type: DataSourceType!, $config: JSON!) {
     createDataSource(name: $name, type: $type, config: $config) {
         id
         name

--- a/ui/graphql/UpdateDataSource.graphql
+++ b/ui/graphql/UpdateDataSource.graphql
@@ -1,4 +1,4 @@
-mutation updateDataSource($id: Int!, $name: String!, $type: DataSourceType!, $config: String!) {
+mutation updateDataSource($id: Int!, $name: String!, $type: DataSourceType!, $config: JSON!) {
     updateDataSource(id: $id, name: $name, type: $type, config: $config) {
         name
     }


### PR DESCRIPTION
@pb82 it turns out that Apollo already supports JSON as a scalar type out of the box