### PR TITLE
Trim data source name

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,14 @@
         "react/sort-comp": "off",
         "react/no-did-update-set-state": "off",
         "jsx-a11y/label-has-for": "off",
-        "no-underscore-dangle": "off"
+        "no-underscore-dangle": "off",
+        "no-param-reassign": [
+            "error",
+            {
+                "props":
+                false
+            }
+        ]
     },
     "plugins": ["mocha"],
     "env": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,8 +33,7 @@
         "no-param-reassign": [
             "error",
             {
-                "props":
-                false
+                "props": false
             }
         ]
     },

--- a/server/models/dataSource.js
+++ b/server/models/dataSource.js
@@ -5,7 +5,7 @@ module.exports = (sequelize, DataTypes) => {
         config: DataTypes.JSON
     });
 
-    DataSource.addHook('beforeValidate', 'nameTrim', (dataSource, options) => {
+    DataSource.addHook("beforeValidate", "nameTrim", dataSource => {
         if (dataSource.name) {
             dataSource.name = dataSource.name.trim();
         }

--- a/server/models/dataSource.js
+++ b/server/models/dataSource.js
@@ -4,5 +4,13 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.ENUM("InMemory", "Postgres"),
         config: DataTypes.JSON
     });
+
+    DataSource.addHook('beforeValidate', 'nameTrim', (dataSource, options) => {
+        if (dataSource.name) {
+            dataSource.name = dataSource.name.trim();
+        }
+        return sequelize.Promise.resolve(dataSource);
+    });
+
     return DataSource;
 };


### PR DESCRIPTION
2 things:

* Show validation error when user types a blank data source name (blank means : `"     "`)
* Trim the data source name when saving. This is done on the backend. Sync UI loads the data from the backend upon saving anyway.