### PR TITLE
Fixes Schema Editor Height with CSS

### DIFF
--- a/ui/components/common/CodeEditor.js
+++ b/ui/components/common/CodeEditor.js
@@ -97,7 +97,7 @@ const CodeEditor = class extends Component {
                             lineHeight: `${lineHeight}px`,
                             whiteSpace: "pre",
                             overflowWrap: "normal",
-                            overflowY: "scroll"
+                            overflowY: "auto"
                         }}
                         className={style["editor-area"]}
                         onKeyDown={ev => this.onEditorKeyDown(ev)}

--- a/ui/components/schema/SchemaContainer.js
+++ b/ui/components/schema/SchemaContainer.js
@@ -11,7 +11,6 @@ import UpdateSchema from "../../graphql/UpdateSchema.graphql";
 import style from "./schemaContainer.css";
 
 const INITIAL_STATE = {
-    height: "100%",
     schema: "",
     error: null,
     saved: true
@@ -22,24 +21,6 @@ class SchemaContainer extends Component {
     constructor(props) {
         super(props);
         this.state = INITIAL_STATE;
-    }
-
-    updateDimensions() {
-        this.setState({
-            height: window.innerHeight - this.calculateHeaderHeight()
-        });
-    }
-
-    componentWillMount() {
-        this.updateDimensions();
-    }
-
-    componentDidMount() {
-        window.addEventListener("resize", () => this.updateDimensions());
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener("resize", () => this.updateDimensions());
     }
 
     calculateHeaderHeight() {
@@ -122,7 +103,7 @@ class SchemaContainer extends Component {
         return (
             <React.Fragment>
                 <CommonToolbar buttons={this.getToolbarButtons()} />
-                <div className={style.flexWrapper} style={{ height: this.state.height }}>
+                <div className={style.flexWrapper}>
                     <div className={style.left}>
                         <CodeEditor
                             value={schema}

--- a/ui/components/schema/schemaContainer.css
+++ b/ui/components/schema/schemaContainer.css
@@ -1,4 +1,5 @@
 .flexWrapper {
+    height: calc(100vh - 206px) !important;
     display: flex;
     flex-direction: row;
     align-items: stretch;

--- a/ui/components/schema/schemaContainer.css
+++ b/ui/components/schema/schemaContainer.css
@@ -1,4 +1,5 @@
 .flexWrapper {
+    /* 206 being the exact height of the components on top of SchemaContainer */
     height: calc(100vh - 206px) !important;
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-7596

This is an alternative for #48 using only CSS. Height is set with `calc(100vh - 206px)` where `206px` is the header and toolbar height.

**EDIT**: forced push and removed all changes not related with the CSS height solution.

~~Changes:~~
- ~~CodeEditor initial props: uses now es6 default value syntax.~~
- ~~CodeEditor lineHeight prop: removed and added to styles.~~
- ~~Inline styles has been moved to css file.~~
- ~~Style class names has been renamed with a react-friendly name.~~
- ~~All resize logic in container has been removed.~~
- ~~SchemaContainer HTML has been simplified, now it uses Col with 2 Row.~~

