### PR TITLE
Making Toolbar Buttons more Customizable

### DIFF
--- a/ui/components/common/CommonToolbar.js
+++ b/ui/components/common/CommonToolbar.js
@@ -6,10 +6,7 @@ const CommonToolbar = ({ buttons, onFilter }) => {
     const elements = buttons && buttons.map(button => (
         <Button
             style={{ float: "right", marginRight: "5px" }}
-            key={button.id}
             bsStyle="primary"
-            onClick={button.cb}
-            disabled={button.enabled === false}
             {...button.props}
         >
             {button.title}

--- a/ui/components/common/CommonToolbar.js
+++ b/ui/components/common/CommonToolbar.js
@@ -2,10 +2,12 @@ import React from "react";
 import { Toolbar, Button } from "patternfly-react";
 import { DebounceInput } from "react-debounce-input";
 
+import styles from "./commonToolbar.css";
+
 const CommonToolbar = ({ buttons, onFilter }) => {
     const elements = buttons && buttons.map(button => (
         <Button
-            style={{ float: "right", marginRight: "5px" }}
+            className={styles.toolbarButton}
             bsStyle="primary"
             {...button.props}
         >

--- a/ui/components/common/commonToolbar.css
+++ b/ui/components/common/commonToolbar.css
@@ -1,0 +1,4 @@
+.toolbarButton {
+  float: right;
+  margin-right: 5px;
+}

--- a/ui/components/data-sources/DataSourcesContainer.js
+++ b/ui/components/data-sources/DataSourcesContainer.js
@@ -70,10 +70,8 @@ class DataSourcesContainer extends Component {
                     filter={filter}
                 />
                 <EditDataSourceDialog
-                    onClose={() => this.setState({
-                        showEditModal: false,
-                        selectedDataSource: null
-                    })}
+                    onClose={() => this.setState({ showEditModal: false,
+                        selectedDataSource: null })}
                     dataSource={selectedDataSource}
                     visible={showEditModal}
                 />
@@ -81,10 +79,8 @@ class DataSourcesContainer extends Component {
                     showModal={showDeleteModal}
                     dataSource={selectedDataSource}
                     filter={filter}
-                    onClose={() => this.setState({
-                        showDeleteModal: false,
-                        selectedDataSource: null
-                    })}
+                    onClose={() => this.setState({ showDeleteModal: false,
+                        selectedDataSource: null })}
                 />
                 <CommonToolbar
                     buttons={this.getToolbarButtons()}

--- a/ui/components/data-sources/DataSourcesContainer.js
+++ b/ui/components/data-sources/DataSourcesContainer.js
@@ -23,7 +23,13 @@ class DataSourcesContainer extends Component {
 
     getToolbarButtons() {
         return [
-            { title: "Add Data Source", cb: () => this.addDataSource(), id: "add_new_data_source" }
+            {
+                title: "Add Data Source",
+                props: {
+                    onClick: () => this.addDataSource(),
+                    key: "add_new_data_source"
+                }
+            }
         ];
     }
 
@@ -64,8 +70,10 @@ class DataSourcesContainer extends Component {
                     filter={filter}
                 />
                 <EditDataSourceDialog
-                    onClose={() => this.setState({ showEditModal: false,
-                        selectedDataSource: null })}
+                    onClose={() => this.setState({
+                        showEditModal: false,
+                        selectedDataSource: null
+                    })}
                     dataSource={selectedDataSource}
                     visible={showEditModal}
                 />
@@ -73,8 +81,10 @@ class DataSourcesContainer extends Component {
                     showModal={showDeleteModal}
                     dataSource={selectedDataSource}
                     filter={filter}
-                    onClose={() => this.setState({ showDeleteModal: false,
-                        selectedDataSource: null })}
+                    onClose={() => this.setState({
+                        showDeleteModal: false,
+                        selectedDataSource: null
+                    })}
                 />
                 <CommonToolbar
                     buttons={this.getToolbarButtons()}

--- a/ui/components/schema/SchemaContainer.js
+++ b/ui/components/schema/SchemaContainer.js
@@ -79,15 +79,19 @@ class SchemaContainer extends Component {
         return [
             {
                 title: "Download Schema",
-                id: "export_schema",
-                enabled: valid,
-                props: { href: `/schema/${id}` }
+                props: {
+                    key: "export_schema",
+                    disabled: !valid,
+                    href: `/schema/${id}`
+                }
             },
             {
                 title: "Save Schema",
-                cb: () => this.save(),
-                id: "save_schema",
-                enabled: true
+                props: {
+                    onClick: () => this.save(),
+                    key: "save_schema",
+                    disabled: false
+                }
             }
         ];
     }


### PR DESCRIPTION
Modify the way buttons are defined in `#getToolbarButtons`, so that any prop can be added. This way buttons are as most customizable as possible.