### PR TITLE
give clear error message when trying to save an empty schema

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -60,3 +60,7 @@ span.list-item-name {
 .spinner {
     margin-top: 100px;
 }
+
+div.list-group-item-container .pficon-close {
+    display: none;
+}

--- a/ui/components/schema/SchemaContainer.js
+++ b/ui/components/schema/SchemaContainer.js
@@ -69,7 +69,7 @@ class SchemaContainer extends Component {
         this.props.mutate({
             variables: {
                 id: getSchema.id,
-                schema: schema
+                schema
             },
             refetchQueries: [{
                 query: GetSchema,

--- a/ui/components/schema/SchemaContainer.js
+++ b/ui/components/schema/SchemaContainer.js
@@ -69,7 +69,7 @@ class SchemaContainer extends Component {
         this.props.mutate({
             variables: {
                 id: getSchema.id,
-                schema: schema || getSchema.schema
+                schema: schema
             },
             refetchQueries: [{
                 query: GetSchema,

--- a/ui/components/schema/StructureView.js
+++ b/ui/components/schema/StructureView.js
@@ -10,6 +10,7 @@ const wellKnownTypes = [
     "String",
     "Boolean",
     "Int",
+    "ID",
     "__Schema",
     "__Type",
     "__TypeKind",


### PR DESCRIPTION
When a user tries to save an empty schema a clear error message is shown. Previously nothing happend (because the last valid one was sent).

Also added `ID` to the list of internal types that we filter from the structure view and remove the cross symbols from the field list: you can collapse the list by clicking the header already.