### PR TITLE
Check for type.fields nullity

### DIFF
--- a/ui/components/schema/TypeList.js
+++ b/ui/components/schema/TypeList.js
@@ -30,12 +30,11 @@ class TypeList extends Component {
         return <div>{error.message}</div>;
     }
 
-    renderAdditionalInfo(type) {
-        const { fields } = type;
-        if (fields.length === 0) {
-            return "n.a.";
+    renderAdditionalInfo({ fields }) {
+        if (fields && fields.length) {
+            return fields.length + (fields.length > 1 ? " fields" : " field");
         }
-        return type.fields.length + (type.fields.length > 1 ? " fields" : " field");
+        return "n.a.";
     }
 
     renderResolverForField(name, data) {


### PR DESCRIPTION
UI crashes when type have no fields.

Sample echema:
```
# Add your schema here
enum DataSourceType {
    InMemory,
    Postgres
},
type Query {
    dataSources(name: String): String
    getOneDataSource(id: Int!): String
    getSchema(name: String!): String
    resolvers(schemaId: Int!, type: String): String
}
```

Error:
```
TypeList.js:35 Uncaught TypeError: Cannot read property 'length' of null`
```