### PR TITLE
Adds Feedback for Save Schema Button

### DIFF
--- a/ui/components/common/CodeEditor.js
+++ b/ui/components/common/CodeEditor.js
@@ -83,6 +83,7 @@ const CodeEditor = class extends Component {
     }
 
     render() {
+        const { disabled } = this.props;
         const { editorValue, lineHeight } = this.state;
         return (
             <div className={style["editor-container"]}>
@@ -94,6 +95,7 @@ const CodeEditor = class extends Component {
                         ref={this.editor}
                         value={editorValue}
                         style={{
+                            opacity: disabled ? 0.2 : 1,
                             lineHeight: `${lineHeight}px`,
                             whiteSpace: "pre",
                             overflowWrap: "normal",
@@ -103,6 +105,7 @@ const CodeEditor = class extends Component {
                         onKeyDown={ev => this.onEditorKeyDown(ev)}
                         onChange={() => this.onEditorChange()}
                         onScroll={() => this.onEditorScroll()}
+                        disabled={disabled}
                     />
                 </div>
             </div>

--- a/ui/components/schema/SchemaContainer.js
+++ b/ui/components/schema/SchemaContainer.js
@@ -104,7 +104,7 @@ class SchemaContainer extends Component {
                 title: "Download Schema",
                 props: {
                     key: "export_schema",
-                    disabled: !valid,
+                    disabled: !valid || saving,
                     href: `/schema/${id}`
                 }
             },

--- a/ui/components/schema/SchemaContainer.js
+++ b/ui/components/schema/SchemaContainer.js
@@ -14,6 +14,7 @@ const INITIAL_STATE = {
     height: "100%",
     schema: "",
     error: null,
+    saving: false,
     saved: true
 };
 
@@ -55,16 +56,19 @@ class SchemaContainer extends Component {
     saveShortcut(e) {
         e.preventDefault();
 
-        const { saved } = this.state;
+        const { saved, saving } = this.state;
 
-        if (!saved) {
-            this.save();
+        if (saved || saving) {
+            return;
         }
+        this.save();
     }
 
     save() {
         const { schema } = this.state;
         const { getSchema } = this.props.data;
+
+        this.setState({ saving: true });
 
         this.props.mutate({
             variables: {
@@ -80,11 +84,13 @@ class SchemaContainer extends Component {
         }).then(() => {
             this.setState({
                 error: null,
+                saving: false,
                 saved: true
             });
         }).catch(error => {
             this.setState({
-                error
+                error,
+                saving: false
             });
         });
     }
@@ -119,6 +125,7 @@ class SchemaContainer extends Component {
 
     renderContent() {
         const { getSchema: { id, schema, compiled } } = this.props.data;
+        const { error, saving } = this.state;
         return (
             <React.Fragment>
                 <CommonToolbar buttons={this.getToolbarButtons()} />
@@ -127,12 +134,13 @@ class SchemaContainer extends Component {
                         <CodeEditor
                             value={schema}
                             onChange={updated => this.onSchemaChange(updated)}
+                            disabled={saving}
                         />
                     </div>
                     <div className={style.right}>
                         <StructureView
                             compiled={JSON.parse(compiled)}
-                            error={this.state.error}
+                            error={error}
                             schemaId={id}
                         />
                     </div>

--- a/ui/components/schema/SchemaContainer.js
+++ b/ui/components/schema/SchemaContainer.js
@@ -97,7 +97,7 @@ class SchemaContainer extends Component {
 
     getToolbarButtons() {
         const { getSchema: { id, valid } } = this.props.data;
-        const { saved } = this.state;
+        const { saved, saving } = this.state;
 
         return [
             {
@@ -109,11 +109,11 @@ class SchemaContainer extends Component {
                 }
             },
             {
-                title: "Save Schema",
+                title: (saving && "Saving Schema...") || (saved && "Schema saved") || "Save Schema",
                 props: {
                     onClick: () => this.save(),
                     key: "save_schema",
-                    disabled: saved
+                    disabled: saved || saving
                 }
             }
         ];


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-7601

**SchemaContainer**'s state has 2 fields now:

- `saved`
- `saving`

Now since this action is asynchronous, button will be disabled and saying _Saving Schema..._ until the mutation has finished. If it's been saved successfully, button will state _Schema saved_, otherwise an error will pop up and the button will go back to _Save Schema_.

Also, added a new prop to **CodeEditor**: `disabled`, making the `textarea` disabled and dim.

Verification steps:

1. Wrap the mutation call `this.props.mutate(...)` inside `#save` with `setTimeOut` so that the action takes some time.
```javascript
save() {
    /* ... */
    setTimeout(() => {
        this.props.mutate({
            /* ... */
        });
    }, 1500);
}
```

2. Add a valid schema at tab *Schema* and click on save.
```
enum DataSourceType {
    InMemory,
    Postgres,
},
type Query {
    dataSources(name: String): String
}
```

3. Add some error to the schema, an error message should appear.
```
dataSources(name: String): void
```

4. Fix it and save again, the error should disappear.