### PR TITLE
fix: ensure pubsub is instantiated

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -9,7 +9,7 @@ exports.postgresConfig = {
     logSql: false
 };
 
-exports.notfier = {
+exports.notifier = {
     enabled: process.env.NODE_ENV !== "test",
     type: "postgres",
     config: {

--- a/server/configNotifiers/configNotifierCreator.js
+++ b/server/configNotifiers/configNotifierCreator.js
@@ -1,17 +1,17 @@
 const { log } = require("../logger");
 const notifiers = require("./notifiers");
-const { notfier } = require("../config");
+const { notifier } = require("../config");
 
 let instance = null;
-if (notfier.enabled && notifiers[notfier.type]) {
-    instance = new notifiers[notfier.type](notfier.config);
+if (notifier.enabled && notifiers[notifier.type]) {
+    instance = new notifiers[notifier.type](notifier.config);
 } else {
     // Notifications will not be available for testing because we don't have
     // a running postgres instance
-    log.warn(`notifier unknown or disabled: ${notfier.type}`);
+    log.warn(`notifier unknown or disabled: ${notifier.type}`);
 }
 
-exports.DEFAULT_CHANNEL = notfier.config.channel;
+exports.DEFAULT_CHANNEL = notifier.config.channel;
 
 exports.publish = (channel, payload) => {
     if (instance) {

--- a/server/configNotifiers/notifiers/index.js
+++ b/server/configNotifiers/notifiers/index.js
@@ -1,3 +1,3 @@
-const { PostgresNotifier } = require("./postgres");
+const PostgresNotifier = require("./postgres");
 
 module.exports = { postgres: PostgresNotifier };


### PR DESCRIPTION
## Description

* I found that the pubsub instance was not being instantiated because we were doing `const { PostgresNotifier } = require('postgres')`, it should have been `const PostgresNotifier`. This meant that notifications about schema changes were not being published.
* `notfier` -> `notifier`

