### PR TITLE
Audit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,9 @@ There is a dependency on having a running postgres server. To run postgres in a 
    ```shell
    docker stop sync-ui
    ```
+
+# Configuration
+
+UI server has some environment variables to be set. If they're not set, defaults for development will be used.
+
+* `AUDIT_LOGGING`:   : If true, audit logs of resolver operations will be logged to stdout. Defaults to true.

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,7 +1,18 @@
 const log = require("pino")();
 const expressPino = require("express-pino-logger")({ level: "silent", logger: log });
 
+const auditLogger = log.child({ tag: "AUDIT" });
+
+const auditLogEnabled = process.env.AUDIT_LOGGING !== "false" && process.env.AUDIT_LOGGING !== false;
+
+function auditLog(obj) {
+    if (auditLogEnabled) {
+        auditLogger.info(obj);
+    }
+}
+
 module.exports = {
     log,
-    expressPino
+    expressPino,
+    auditLog
 };


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-7639

What:
* Added a special logger function that adds a tag "AUDIT" to the output JSON.
* That tag will be used to search things when we centralize logging on OpenShift with EFK.
* Used that function in create/update/delete operations for resources (schema, data source, resolver)
* No user/client information is logged ATM as we don't have auth yet.

How to verify:
* Just start the server, execute bunch of operations and check out the STDOUT. There will be some logs with tag AUDIT.

Note:
I used my best judgement on what to log (e.g. logging config for data sources) but I am open to discussions.