### PR TITLE
show validations per field for postgres

### DIFF
--- a/ui/components/data-sources/BaseDataSourceDialog.js
+++ b/ui/components/data-sources/BaseDataSourceDialog.js
@@ -65,21 +65,29 @@ class BaseDataSourceDialog extends Component {
     onPostgresOptionsChange(postgresOptions) {
         const { url, port, database, username } = postgresOptions;
 
-        const optionsValidation = Validate([
-            Validators.String.nonBlank, url,
-            Validators.String.nonBlank, database,
-            Validators.String.nonBlank, username,
-            Validators.Port.valid, port
-        ]);
+        // Set the initial validation state and assume that port is valid
+        // (because we set a default value there)
+        const validationDetails = {
+            url: "error",
+            database: "error",
+            username: "error",
+            port: "success"
+        };
+
+        Validate([
+            Validators.String.nonBlank, url, "url",
+            Validators.String.nonBlank, database, "database",
+            Validators.String.nonBlank, username, "username",
+            Validators.Port.valid, port, "port"
+        ], validationDetails);
 
         const { validations } = this.state;
-        const newValidations = { ...validations, optionsValidation };
-
+        const newValidations = { ...validations, ...validationDetails };
         this.setState({ postgresOptions, validations: newValidations });
     }
 
     renderSpecificOptionsFormsForSelectedType() {
-        const { type, inMemoryOptions, postgresOptions } = this.state;
+        const { type, inMemoryOptions, postgresOptions, validations } = this.state;
 
         switch (type) {
             case DataSourceType.InMemory:
@@ -95,6 +103,7 @@ class BaseDataSourceDialog extends Component {
                     <PostgresOptions
                         isDisabled={this.isDisabled}
                         options={postgresOptions}
+                        validations={validations}
                         onOptionsChange={newOps => this.onPostgresOptionsChange(newOps)}
                     />
                 );

--- a/ui/components/data-sources/options/PostgresOptions.js
+++ b/ui/components/data-sources/options/PostgresOptions.js
@@ -5,9 +5,9 @@ import {
     FormControl
 } from "patternfly-react";
 
-const PostgresOptions = ({ options, onOptionsChange, isDisabled }) => (
+const PostgresOptions = ({ options, onOptionsChange, isDisabled, validations }) => (
     <React.Fragment>
-        <FormGroup controlId="url">
+        <FormGroup controlId="url" validationState={validations.url}>
             <Col sm={3}>Server</Col>
             <Col sm={9}>
                 <FormControl
@@ -21,7 +21,7 @@ const PostgresOptions = ({ options, onOptionsChange, isDisabled }) => (
                 />
             </Col>
         </FormGroup>
-        <FormGroup controlId="port">
+        <FormGroup controlId="port" validationState={validations.port}>
             <Col sm={3}>Port</Col>
             <Col sm={9}>
                 <FormControl
@@ -35,7 +35,7 @@ const PostgresOptions = ({ options, onOptionsChange, isDisabled }) => (
                 />
             </Col>
         </FormGroup>
-        <FormGroup controlId="database">
+        <FormGroup controlId="database" validationState={validations.database}>
             <Col sm={3}>Database</Col>
             <Col sm={9}>
                 <FormControl
@@ -49,7 +49,7 @@ const PostgresOptions = ({ options, onOptionsChange, isDisabled }) => (
                 />
             </Col>
         </FormGroup>
-        <FormGroup controlId="username">
+        <FormGroup controlId="username" validationState={validations.username}>
             <Col sm={3}>Username</Col>
             <Col sm={9}>
                 <FormControl
@@ -63,7 +63,7 @@ const PostgresOptions = ({ options, onOptionsChange, isDisabled }) => (
                 />
             </Col>
         </FormGroup>
-        <FormGroup controlId="password">
+        <FormGroup controlId="password" validationState={validations.password}>
             <Col sm={3}>Password</Col>
             <Col sm={9}>
                 <FormControl

--- a/ui/helper/Validators.js
+++ b/ui/helper/Validators.js
@@ -26,21 +26,35 @@ const Validators = {
  *  <Validator N>, <Input Value N>
  * ]
  *
- * It always has to be exactly one validator per input value, so the total length
- * of the array mod 2 must be zero.
+ * or
+ *
+ * [
+ *  <Validator 1>, <Input Value 1>, <Field Name>
+ *  ...
+ *  <Validator N>, <Input Value N>, <Field Name>
+ * ]
  *
  * @param validations The validations array
+ * @param details An object to store the validation results per field. Must be set if Field Names
+ * are used in the validations
  * @returns {string} "success" on success, otherwise "error"
  */
-const Validate = validations => {
+const Validate = (validations, details) => {
     let result = false;
     let index = 0;
 
-    if (validations && validations.length % 2 === 0) {
+    // One validation takes 3 arguments if fiel names are used (validator, input valud and field name)
+    // and only two if not (validator, input value)
+    let increase = details ? 3 : 2 ;
+
+    if (validations && validations.length % increase === 0) {
         result = true; // Init value
         while (result && index < validations.length) {
             result = result && validations[index](validations[index + 1]);
-            index += 2;
+            if (details) {
+                details[validations[index + 2]] = result ? "success" : "error";
+            }
+            index += increase;
         }
     }
 

--- a/ui/helper/Validators.js
+++ b/ui/helper/Validators.js
@@ -45,7 +45,7 @@ const Validate = (validations, details) => {
 
     // One validation takes 3 arguments if fiel names are used (validator, input valud and field name)
     // and only two if not (validator, input value)
-    let increase = details ? 3 : 2 ;
+    const increase = details ? 3 : 2;
 
     if (validations && validations.length % increase === 0) {
         result = true; // Init value


### PR DESCRIPTION
## Motivation

Show the validation state for each field when the postgres options are selected. This is achieved by extending the `Validate` function and allowing it to pass in field names and validation details.