### PR TITLE
dont force close the connection

### DIFF
--- a/server/dataSourceValidator/validators/postgres.js
+++ b/server/dataSourceValidator/validators/postgres.js
@@ -63,18 +63,7 @@ module.exports = async config => {
         return { status: true };
     } finally {
         if (client) {
-            // force kill the connection if it is open or end it if it is not
-            // see https://github.com/brianc/node-pg-pool/blob/277dc508daea03a8f6c0bcc3c534cab5b2501b12/index.js#L208-L209
-            try {
-                // do not block on ending the client
-                if (client.connection) {
-                    client.connection.stream.destroy();
-                } else {
-                    client.end();
-                }
-            } catch (ex) {
-                // do nothing even when there's an error.
-            }
+            client.end();
         }
     }
 };


### PR DESCRIPTION
## Motivation

`client.connection.stream.destroy();` was throwing un unhandled exception. Just using `client.end()` seems to work.