### PR TITLE
Post hooks optional

### DIFF
--- a/server/gql/schema.js
+++ b/server/gql/schema.js
@@ -55,8 +55,8 @@ const Schema = buildSchema(`
         id: Int! 
         type: String!
         field: String!
-        preHook: String!
-        postHook: String!
+        preHook: String
+        postHook: String
         requestMapping: String!
         responseMapping: String!
         DataSource: DataSource!


### PR DESCRIPTION
## Motivation

Post hooks should be optional in graphql.
Needed that for the demo.