### PR TITLE
Fixed cursor positioning after hitting tab button

### DIFF
--- a/ui/components/common/CodeEditor.js
+++ b/ui/components/common/CodeEditor.js
@@ -22,7 +22,16 @@ const CodeEditor = class extends Component {
             // When the user presses tab we prevent the default propagation, so we need to udpate
             // the state manually here
             this.props.onChange(`${value.substring(0, selectionStart)}\t${value.substring(selectionEnd)}`);
+            this.updateCursorPosition(selectionStart + 1);
         }
+    }
+
+    updateCursorPosition(position) {
+        const editor = this.editor.current;
+        this.setState({}, () => {
+            editor.selectionStart = position;
+            editor.selectionEnd = position;
+        });
     }
 
     onEditorScroll() {

--- a/ui/components/common/CodeEditor.js
+++ b/ui/components/common/CodeEditor.js
@@ -9,6 +9,8 @@ const CodeEditor = class extends Component {
 
         this.editor = createRef();
         this.gutter = createRef();
+        this.cursorPosition = 0;
+        this.tabWasPressed = false;
     }
 
     // Deal with the tab key: we don't want to loose focus on the
@@ -18,20 +20,26 @@ const CodeEditor = class extends Component {
         if (event.keyCode === 9) {
             event.preventDefault();
             const { selectionStart, selectionEnd, value } = editor;
+            this.cursorPosition = selectionStart;
+            this.tabWasPressed = true;
 
             // When the user presses tab we prevent the default propagation, so we need to udpate
             // the state manually here
             this.props.onChange(`${value.substring(0, selectionStart)}\t${value.substring(selectionEnd)}`);
-            this.updateCursorPosition(selectionStart + 1);
+        }
+    }
+
+    componentDidUpdate() {
+        if (this.tabWasPressed) {
+            this.updateCursorPosition(this.cursorPosition + 1);
+            this.tabWasPressed = false;
         }
     }
 
     updateCursorPosition(position) {
         const editor = this.editor.current;
-        this.setState({}, () => {
-            editor.selectionStart = position;
-            editor.selectionEnd = position;
-        });
+        editor.selectionStart = position;
+        editor.selectionEnd = position;
     }
 
     onEditorScroll() {

--- a/ui/components/common/CodeEditor.js
+++ b/ui/components/common/CodeEditor.js
@@ -9,8 +9,7 @@ const CodeEditor = class extends Component {
 
         this.editor = createRef();
         this.gutter = createRef();
-        this.cursorPosition = 0;
-        this.tabWasPressed = false;
+        this.cursorPositionAfterTabPress = null;
     }
 
     // Deal with the tab key: we don't want to loose focus on the
@@ -20,8 +19,7 @@ const CodeEditor = class extends Component {
         if (event.keyCode === 9) {
             event.preventDefault();
             const { selectionStart, selectionEnd, value } = editor;
-            this.cursorPosition = selectionStart;
-            this.tabWasPressed = true;
+            this.cursorPositionAfterTabPress = selectionStart;
 
             // When the user presses tab we prevent the default propagation, so we need to udpate
             // the state manually here
@@ -30,9 +28,9 @@ const CodeEditor = class extends Component {
     }
 
     componentDidUpdate() {
-        if (this.tabWasPressed) {
-            this.updateCursorPosition(this.cursorPosition + 1);
-            this.tabWasPressed = false;
+        if (this.cursorPositionAfterTabPress !== null) {
+            this.updateCursorPosition(this.cursorPositionAfterTabPress + 1);
+            this.cursorPositionAfterTabPress = null;
         }
     }
 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-7789
## What
Previously, in the schema editor, when you hit TAB button, new tab character was added as expected, but a cursor jumped to the last character of the whole schema
## How
~~By passing a callback to `setState` function, which may not be the best approach.
Unfortunately the only one that worked for me (feel free to suggest a better way)~~
Record position of cursor after Tab key was hit and fix its position in `componentDidUpdate` lifecycle method.
## Verification Steps
Go to schema editor, type couple of lines of text, move cursor to the middle (between characters) and press tab. It should behave like you're used to in common text editor.