### PR TITLE
Add scroll to data sources list

### DIFF
--- a/ui/components/data-sources/DataSourcesContainer.css
+++ b/ui/components/data-sources/DataSourcesContainer.css
@@ -1,0 +1,8 @@
+.flexWrapper {
+  composes: flexWrapper from "../common/common.css";
+}
+
+.dataSourcesListContainer {
+  width: 100%;
+  overflow-y: auto;
+}

--- a/ui/components/data-sources/DataSourcesContainer.js
+++ b/ui/components/data-sources/DataSourcesContainer.js
@@ -6,6 +6,8 @@ import { EditDataSourceDialog } from "./EditDataSourceDialog";
 import { DataSourcesList } from "./DataSourcesList";
 import { DeleteDataSourceDialog } from "./DeleteDataSourceDialog";
 
+import styles from "./DataSourcesContainer.css";
+
 const INITIAL_STATE = {
     showAddModal: false,
     showEditModal: false,
@@ -96,14 +98,16 @@ class DataSourcesContainer extends Component {
                     onFilterChange={f => this.onFilterChange(f)}
                     filter={filter}
                 />
-                <div>
-                    <DataSourcesList
-                        filter={filter}
-                        onCreate={() => this.addDataSource()}
-                        onEditDataSource={dataSource => this.editDataSource(dataSource)}
-                        onDeleteDataSource={dataSource => this.deleteDataSource(dataSource)}
-                        onClearFilter={() => this.clearFilter()}
-                    />
+                <div className={styles.flexWrapper}>
+                    <div className={styles.dataSourcesListContainer}>
+                        <DataSourcesList
+                            filter={filter}
+                            onCreate={() => this.addDataSource()}
+                            onEditDataSource={dataSource => this.editDataSource(dataSource)}
+                            onDeleteDataSource={dataSource => this.deleteDataSource(dataSource)}
+                            onClearFilter={() => this.clearFilter()}
+                        />
+                    </div>
                 </div>
             </React.Fragment>
         );


### PR DESCRIPTION
## Motivation

When the list of data sources is big enough, the whole screen will scroll. Only the list should scroll, keeping toolbar and headers static (like the lists in Schema and Resolvers).

https://issues.jboss.org/browse/AEROGEAR-7831

## How

Added styling.
