### PR TITLE
Adds resolver counters and learnMore links to the Resolvers tab

### DIFF
--- a/ui/components/common/ResolversCount.css
+++ b/ui/components/common/ResolversCount.css
@@ -1,0 +1,18 @@
+.resolversCount {
+    flex: 1;
+    text-align: end;
+    display: inline-block;
+    align-self: flex-end;
+}
+
+.resolversCount > p {
+    font-weight: 300;
+    margin: 0;
+}
+
+.resolversCount > p > span {
+    font-weight: 400;
+    font-size: 14px;
+    margin-right: 5px;
+    letter-spacing: 2px;
+}

--- a/ui/components/common/ResolversCount.js
+++ b/ui/components/common/ResolversCount.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { Icon } from "patternfly-react";
+
+import { resolversCount } from "./ResolversCount.css";
+
+const ResolversCount = ({ total, defined }) => (
+    <div className={resolversCount}>
+        <p>
+            {defined === total ? <Icon type="pf" name="ok" /> : null}
+            <span>{defined}/{total}</span>
+            {total === 1 ? "Resolver" : "Resolvers"}
+        </p>
+    </div>
+);
+
+export { ResolversCount };

--- a/ui/components/common/ResolversCount.js
+++ b/ui/components/common/ResolversCount.js
@@ -4,14 +4,22 @@ import { Icon } from "patternfly-react";
 
 import { resolversCount } from "./ResolversCount.css";
 
-const ResolversCount = ({ total, defined }) => (
-    <div className={resolversCount}>
-        <p>
-            {defined === total ? <Icon type="pf" name="ok" /> : null}
-            <span>{defined}/{total}</span>
-            {total === 1 ? "Resolver" : "Resolvers"}
-        </p>
-    </div>
-);
+const ResolversCount = ({ fields = [], resolvers = [] }) => {
+    const total = fields.length;
+    const defined = fields.reduce((prev, curr) => {
+        const resolver = resolvers.find(r => r.field === curr.name);
+        return resolver ? prev + 1 : prev;
+    }, 0);
+
+    return (
+        <div className={resolversCount}>
+            <p>
+                {defined === total ? <Icon type="pf" name="ok" /> : null}
+                <span>{defined}/{total}</span>
+                {total === 1 ? "Resolver" : "Resolvers"}
+            </p>
+        </div>
+    );
+};
 
 export { ResolversCount };

--- a/ui/components/common/index.js
+++ b/ui/components/common/index.js
@@ -1,3 +1,4 @@
 export * from "./CommonToolbar";
 export * from "./CodeEditor";
 export * from "../../helper/Validators";
+export * from "./ResolversCount";

--- a/ui/components/resolvers/CustomTypeResolversList.js
+++ b/ui/components/resolvers/CustomTypeResolversList.js
@@ -3,6 +3,7 @@ import { ListView } from "patternfly-react";
 import { CustomTypeResolversListItem } from "./resolvers-list-item";
 
 import styles from "./ResolversListItem.css";
+import { learnMore } from "../common/common.css";
 
 /**
  * A CustomTypeItem is used to render a user defined GraphQL type in the resolver tab's
@@ -10,10 +11,17 @@ import styles from "./ResolversListItem.css";
  */
 const CustomTypeResolversList = props => {
     const { items, text, schemaId, kind, onClick } = props;
-    const { resolversContent, resolversHeader, resolversList } = styles;
+    const { resolversContent, resolversHeader, resolversHeaderName, resolversList } = styles;
     return (
         <div className={resolversContent}>
-            <div className={resolversHeader}>{text}</div>
+            <div className={resolversHeader}>
+                <div className={resolversHeaderName}>
+                    <span style={{ marginRight: "12px" }}>{text}</span>
+                    <span className={learnMore}>
+                        <a href="https://www.google.es">Learn More <span className="fa fa-external-link" /></a>
+                    </span>
+                </div>
+            </div>
             <ListView className={resolversList}>
                 {items.map(item => (
                     <CustomTypeResolversListItem

--- a/ui/components/resolvers/GenericTypeResolversList.js
+++ b/ui/components/resolvers/GenericTypeResolversList.js
@@ -1,9 +1,12 @@
 import React from "react";
 import { Query } from "react-apollo";
-import { Spinner, ListView } from "patternfly-react";
+import {
+    Spinner, ListView, Icon
+} from "patternfly-react";
 import { GenericTypeResolversListItem } from "./resolvers-list-item";
 
 import styles from "./ResolversListItem.css";
+import { learnMore } from "../common/common.css";
 
 import GetResolvers from "../../graphql/GetResolvers.graphql";
 
@@ -23,7 +26,7 @@ const GenericTypeResolversList = ({ schemaId, items, text, kind, onClick }) => {
         return null;
     }
 
-    const { resolversContent, resolversHeader, resolversList } = styles;
+    const { resolversContent, resolversHeader, resolversHeaderName, resolversHeaderCount, resolversList } = styles;
     const { name, fields } = items[0];
     return (
         <Query key={name} query={GetResolvers} variables={{ schemaId, type: name }}>
@@ -53,7 +56,19 @@ const GenericTypeResolversList = ({ schemaId, items, text, kind, onClick }) => {
                 return (
                     <div className={resolversContent}>
                         <div className={resolversHeader}>
-                            <span>{text}</span>
+                            <div className={resolversHeaderName}>
+                                <span style={{ marginRight: "12px" }}>{text}</span>
+                                <span className={learnMore}>
+                                    <a href="https://www.google.es">Learn More <span className="fa fa-external-link" /></a>
+                                </span>
+                            </div>
+                            <div className={resolversHeaderCount}>
+                                <p>
+                                    <Icon type="pf" name="ok" />
+                                    <span>0/{data.resolvers.length}</span>
+                                    {data.resolvers.length === 1 ? "Resolver" : "Resolvers"}
+                                </p>
+                            </div>
                         </div>
                         <ListView className={resolversList}>
                             { list }

--- a/ui/components/resolvers/GenericTypeResolversList.js
+++ b/ui/components/resolvers/GenericTypeResolversList.js
@@ -52,11 +52,6 @@ const GenericTypeResolversList = ({ schemaId, items, text, kind, onClick }) => {
                     );
                 });
 
-                const definedResolvers = fields.reduce((prev, curr) => {
-                    const resolver = data.resolvers.find(r => r.field === curr.name);
-                    return resolver ? prev + 1 : prev;
-                }, 0);
-
                 return (
                     <div className={resolversContent}>
                         <div className={resolversHeader}>
@@ -66,7 +61,7 @@ const GenericTypeResolversList = ({ schemaId, items, text, kind, onClick }) => {
                                     <a href="https://www.google.es">Learn More <span className="fa fa-external-link" /></a>
                                 </span>
                             </div>
-                            {kind !== "subscription" ? <ResolversCount total={fields.length} defined={definedResolvers} /> : null}
+                            {kind !== "subscription" ? <ResolversCount fields={fields} resolvers={data.resolvers} /> : null}
                         </div>
                         <ListView className={resolversList}>
                             { list }

--- a/ui/components/resolvers/GenericTypeResolversList.js
+++ b/ui/components/resolvers/GenericTypeResolversList.js
@@ -1,9 +1,8 @@
 import React from "react";
 import { Query } from "react-apollo";
-import {
-    Spinner, ListView, Icon
-} from "patternfly-react";
+import { Spinner, ListView } from "patternfly-react";
 import { GenericTypeResolversListItem } from "./resolvers-list-item";
+import { ResolversCount } from "../common";
 
 import styles from "./ResolversListItem.css";
 import { learnMore } from "../common/common.css";
@@ -26,7 +25,7 @@ const GenericTypeResolversList = ({ schemaId, items, text, kind, onClick }) => {
         return null;
     }
 
-    const { resolversContent, resolversHeader, resolversHeaderName, resolversHeaderCount, resolversList } = styles;
+    const { resolversContent, resolversHeader, resolversHeaderName, resolversList } = styles;
     const { name, fields } = items[0];
     return (
         <Query key={name} query={GetResolvers} variables={{ schemaId, type: name }}>
@@ -67,15 +66,7 @@ const GenericTypeResolversList = ({ schemaId, items, text, kind, onClick }) => {
                                     <a href="https://www.google.es">Learn More <span className="fa fa-external-link" /></a>
                                 </span>
                             </div>
-                            {kind !== "subscription" ? (
-                                <div className={resolversHeaderCount}>
-                                    <p>
-                                        {definedResolvers === fields.length ? <Icon type="pf" name="ok" /> : null}
-                                        <span>{definedResolvers}/{fields.length}</span>
-                                        {fields.length === 1 ? "Resolver" : "Resolvers"}
-                                    </p>
-                                </div>
-                            ) : null}
+                            {kind !== "subscription" ? <ResolversCount total={fields.length} defined={definedResolvers} /> : null}
                         </div>
                         <ListView className={resolversList}>
                             { list }

--- a/ui/components/resolvers/GenericTypeResolversList.js
+++ b/ui/components/resolvers/GenericTypeResolversList.js
@@ -53,6 +53,11 @@ const GenericTypeResolversList = ({ schemaId, items, text, kind, onClick }) => {
                     );
                 });
 
+                const definedResolvers = fields.reduce((prev, curr) => {
+                    const resolver = data.resolvers.find(r => r.field === curr.name);
+                    return resolver ? prev + 1 : prev;
+                }, 0);
+
                 return (
                     <div className={resolversContent}>
                         <div className={resolversHeader}>
@@ -62,13 +67,15 @@ const GenericTypeResolversList = ({ schemaId, items, text, kind, onClick }) => {
                                     <a href="https://www.google.es">Learn More <span className="fa fa-external-link" /></a>
                                 </span>
                             </div>
-                            <div className={resolversHeaderCount}>
-                                <p>
-                                    <Icon type="pf" name="ok" />
-                                    <span>0/{data.resolvers.length}</span>
-                                    {data.resolvers.length === 1 ? "Resolver" : "Resolvers"}
-                                </p>
-                            </div>
+                            {kind !== "subscription" ? (
+                                <div className={resolversHeaderCount}>
+                                    <p>
+                                        {definedResolvers === fields.length ? <Icon type="pf" name="ok" /> : null}
+                                        <span>{definedResolvers}/{fields.length}</span>
+                                        {fields.length === 1 ? "Resolver" : "Resolvers"}
+                                    </p>
+                                </div>
+                            ) : null}
                         </div>
                         <ListView className={resolversList}>
                             { list }

--- a/ui/components/resolvers/ResolversListItem.css
+++ b/ui/components/resolvers/ResolversListItem.css
@@ -37,9 +37,7 @@
     overflow-wrap: break-word;
 }
 
-.itemType {
-
-}
+.itemType {}
 
 .resolverFieldRow {
     composes: structureFieldRow from "../schema/TypeList.css";
@@ -49,12 +47,14 @@
     composes: structureItemRow from "../schema/TypeList.css";
 }
 
-.headingDescription {
-    
+.headingDescription {}
+
+.headingDescriptionContainer {
+    display: flex;
+    margin-right: -40px;
 }
 
-.headingResolverSet,
-.headingResolverUnset {
+.headingResolverSet, .headingResolverUnset {
     width: 100%;
     text-align: end;
     font-weight: 400;

--- a/ui/components/resolvers/ResolversListItem.css
+++ b/ui/components/resolvers/ResolversListItem.css
@@ -12,24 +12,6 @@
     flex: 1;
 }
 
-.resolversHeaderCount {
-    flex: 1;
-    text-align: end;
-    display: inline-block;
-    align-self: flex-end;
-}
-
-.resolversHeaderCount > p {
-    font-weight: 300;
-    margin: 0;
-}
-
-.resolversHeaderCount > p > span {
-    font-weight: 400;
-    font-size: 14px;
-    margin-right: 5px;
-}
-
 .resolversContent {
     padding-left: 20px;
     padding-right: 20px;

--- a/ui/components/resolvers/ResolversListItem.css
+++ b/ui/components/resolvers/ResolversListItem.css
@@ -26,7 +26,7 @@
 
 .resolversHeaderCount > p > span {
     font-weight: 400;
-    font-size: 16px;
+    font-size: 14px;
     margin-right: 5px;
 }
 

--- a/ui/components/resolvers/ResolversListItem.css
+++ b/ui/components/resolvers/ResolversListItem.css
@@ -1,8 +1,33 @@
 .resolversHeader {
-    padding-top: 30px;
-    font-size: 18px;
+    display: flex;
+    flex-direction: row;
     padding-left: 15px;
     padding-bottom: 5px;
+    padding-top: 30px;
+    padding-right: 15px;
+}
+
+.resolversHeaderName {
+    font-size: 18px;
+    flex: 1;
+}
+
+.resolversHeaderCount {
+    flex: 1;
+    text-align: end;
+    display: inline-block;
+    align-self: flex-end;
+}
+
+.resolversHeaderCount > p {
+    font-weight: 300;
+    margin: 0;
+}
+
+.resolversHeaderCount > p > span {
+    font-weight: 400;
+    font-size: 16px;
+    margin-right: 5px;
 }
 
 .resolversContent {

--- a/ui/components/resolvers/resolvers-list-item/CustomTypeResolversListItem.js
+++ b/ui/components/resolvers/resolvers-list-item/CustomTypeResolversListItem.js
@@ -8,7 +8,6 @@ import {
     Col
 } from "patternfly-react";
 import { CustomTypeArgs } from "./CustomTypeArgs";
-import { ResolversCount } from "../../common";
 
 import GetResolvers from "../../../graphql/GetResolvers.graphql";
 
@@ -37,7 +36,6 @@ const CustomTypeResolversListItem = ({ schemaId, type, item, onClick }) => {
                             <span style={{ fontWeight: "600" }}>{fields.length}</span>
                             <span style={{ fontWeight: "300" }}>{fields.length !== 1 ? " Arguments" : " Argument"}</span>
                         </span>
-                        <ResolversCount fields={fields} resolvers={data.resolvers} />
                     </div>
                 );
 

--- a/ui/components/resolvers/resolvers-list-item/CustomTypeResolversListItem.js
+++ b/ui/components/resolvers/resolvers-list-item/CustomTypeResolversListItem.js
@@ -31,18 +31,13 @@ const CustomTypeResolversListItem = ({ schemaId, type, item, onClick }) => {
                     return error.message;
                 }
 
-                const definedResolvers = fields.reduce((prev, curr) => {
-                    const resolver = data.resolvers.find(r => r.field === curr.name);
-                    return resolver ? prev + 1 : prev;
-                }, 0);
-
                 const fieldsText = (
                     <div className={headingDescriptionContainer}>
                         <span className={headingDescription}>
                             <span style={{ fontWeight: "600" }}>{fields.length}</span>
                             <span style={{ fontWeight: "300" }}>{fields.length !== 1 ? " Arguments" : " Argument"}</span>
                         </span>
-                        <ResolversCount total={fields.length} defined={definedResolvers} />
+                        <ResolversCount fields={fields} resolvers={data.resolvers} />
                     </div>
                 );
 

--- a/ui/components/resolvers/resolvers-list-item/CustomTypeResolversListItem.js
+++ b/ui/components/resolvers/resolvers-list-item/CustomTypeResolversListItem.js
@@ -8,24 +8,19 @@ import {
     Col
 } from "patternfly-react";
 import { CustomTypeArgs } from "./CustomTypeArgs";
+import { ResolversCount } from "../../common";
 
 import GetResolvers from "../../../graphql/GetResolvers.graphql";
 
 import {
     headingDescription,
+    headingDescriptionContainer,
     resolversHeading,
     resolverFieldRow
 } from "../ResolversListItem.css";
 
 const CustomTypeResolversListItem = ({ schemaId, type, item, onClick }) => {
     const { fields, name } = item;
-    const fieldsText = (
-        <span className={headingDescription}>
-            <span style={{ fontWeight: "600" }}>{fields.length}</span>
-            <span style={{ fontWeight: "300" }}>{fields.length !== 1 ? " Arguments" : " Argument"}</span>
-        </span>
-    );
-
     return (
         <Query key={name} query={GetResolvers} variables={{ schemaId, type: name }}>
             {({ loading, error, data }) => {
@@ -35,6 +30,21 @@ const CustomTypeResolversListItem = ({ schemaId, type, item, onClick }) => {
                 if (error) {
                     return error.message;
                 }
+
+                const definedResolvers = fields.reduce((prev, curr) => {
+                    const resolver = data.resolvers.find(r => r.field === curr.name);
+                    return resolver ? prev + 1 : prev;
+                }, 0);
+
+                const fieldsText = (
+                    <div className={headingDescriptionContainer}>
+                        <span className={headingDescription}>
+                            <span style={{ fontWeight: "600" }}>{fields.length}</span>
+                            <span style={{ fontWeight: "300" }}>{fields.length !== 1 ? " Arguments" : " Argument"}</span>
+                        </span>
+                        <ResolversCount total={fields.length} defined={definedResolvers} />
+                    </div>
+                );
 
                 return (
                     <ListViewItem


### PR DESCRIPTION
## Motivation
UI mockup has resolver counters in the resolvers structure view: https://redhat.invisionapp.com/share/SVMB0QW6MR9#/screens/311097940

![screen shot 2018-08-30 at 10 57 48](https://user-images.githubusercontent.com/11672286/44841568-f18aec80-ac43-11e8-944d-7f2636671abd.png)

![screen shot 2018-08-30 at 11 09 14](https://user-images.githubusercontent.com/11672286/44842060-28153700-ac45-11e8-94a8-899a1a2031e1.png)


## Verification Steps

1. Open the Resolvers tab
2. The counters must show the exact total of resolvers for a particular type (Query, Mutation and Custom)
3. Subscriptions neither have resolvers nor a counter.
4. When all resolvers possible for a type has been created, a green tick appears.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member  

## Additional Notes
Also adds "learn more" links to the headers, url is dummy until relevant docs are added.