### PR TITLE
Hides "Queries" tab

### DIFF
--- a/ui/components/app.js
+++ b/ui/components/app.js
@@ -36,9 +36,6 @@ const App = () => (
                         <NavItem eventKey={2}>
                             <div>Resolvers</div>
                         </NavItem>
-                        <NavItem eventKey={3}>
-                            <div>Queries</div>
-                        </NavItem>
                     </Nav>
                     {/* Tabs Content */}
                     <TabContent>
@@ -50,9 +47,6 @@ const App = () => (
                         </TabPane>
                         <TabPane eventKey={2} animation={false}>
                             <ResolversContainer />
-                        </TabPane>
-                        <TabPane eventKey={3} animation={false}>
-                            <QueriesContainer />
                         </TabPane>
                     </TabContent>
                 </div>

--- a/ui/components/app.js
+++ b/ui/components/app.js
@@ -10,7 +10,6 @@ import {
 
 import { DataSourcesContainer } from "./data-sources";
 import { SchemaContainer } from "./schema";
-import { QueriesContainer } from "./queries";
 import { ResolversContainer } from "./resolvers";
 
 import { header, tabs } from "./App.css";


### PR DESCRIPTION
## Motivation
"Queries" is nothing more than a blank page, hence for the release it should be concealed.

![screen shot 2018-08-30 at 11 13 11](https://user-images.githubusercontent.com/11672286/44842295-be495d00-ac45-11e8-98f4-2190d338ae10.png)


## Verification Steps
Tab "Queries" no longer appears in the UI.

