### PR TITLE
Closing resolver editor when associated datasource does not exist

### DIFF
--- a/ui/components/resolvers/resolvers-list-item/AdditionalInfo.js
+++ b/ui/components/resolvers/resolvers-list-item/AdditionalInfo.js
@@ -5,10 +5,11 @@ import { headingResolverSet, headingResolverUnset } from "../ResolversListItem.c
 class AdditionalInfo extends Component {
 
     componentWillReceiveProps(nextProps) {
-        const { schemaId, type, field, resolver, onClick } = this.props;
+        const { resolver, onClick } = this.props;
 
+        // Close resolver editor when associated resolver does not exist
         if (resolver && !nextProps.resolver) {
-            onClick({ schemaId, type, field: field.name });
+            onClick(null);
         }
     }
 

--- a/ui/components/resolvers/resolvers-list-item/CustomTypeArgs.js
+++ b/ui/components/resolvers/resolvers-list-item/CustomTypeArgs.js
@@ -10,10 +10,11 @@ import styles from "../ResolversListItem.css";
 class CustomTypeArgs extends Component {
 
     componentWillReceiveProps(nextProps) {
-        const { schemaId, type, field, resolver, onClick } = this.props;
+        const { resolver, onClick } = this.props;
 
+        // Close resolver editor when associated resolver does not exist
         if (resolver && !nextProps.resolver) {
-            onClick({ schemaId, type, field: field.name });
+            onClick(null);
         }
     }
 


### PR DESCRIPTION
## Motivation
https://drive.google.com/open?id=1VY7UZX7ehRUKe33XgxNXwq8kTxXgPEJE
## What
Hide resolver editor when associated resolver does not exist
## Why
See video from link above
## Verification Steps
1. Create data source
2. Go to Resolvers, add some resolver to query, mutation,...
3. Go to datasources tab
4. Delete the datasource which is associated with the resolver you've added (it should be also open in the Resolver editor)
5. Go back to Resolver tab
6. Editor should be closed (should show `Select an item to view and edit its details` message)
## Checklist:

- [X] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 
 

