### PR TITLE
extracts LearMore component and fixes doc urls

### DIFF
--- a/ui/components/common/DefaultEmptyView.js
+++ b/ui/components/common/DefaultEmptyView.js
@@ -4,12 +4,9 @@ import {
     EmptyStateIcon,
     EmptyStateTitle
 } from "patternfly-react";
+import { LearnMore } from "./LearnMore";
 
-import {
-    emptyContainer,
-    emptyTitle,
-    learnMore
-} from "./defaultEmptyView.css";
+import { emptyContainer, emptyTitle } from "./defaultEmptyView.css";
 
 const DefaultEmptyView = ({ text, infoText, infoURL }) => (
     <EmptyState className={emptyContainer}>
@@ -17,11 +14,7 @@ const DefaultEmptyView = ({ text, infoText, infoURL }) => (
         <EmptyStateTitle className={emptyTitle}>
             {text}
         </EmptyStateTitle>
-        {infoText ? (
-            <span className={learnMore}>
-                <a href={infoURL}>{infoText} <span className="fa fa-external-link" /></a>
-            </span>
-        ) : null}
+        {infoText ? <LearnMore text={infoText} url={infoURL} /> : null}
     </EmptyState>
 );
 

--- a/ui/components/common/LearnMore.css
+++ b/ui/components/common/LearnMore.css
@@ -1,0 +1,7 @@
+.wrapper {
+  font-size: 9px;
+}
+
+.wrapper > a > span {
+  margin-left: 3px;
+}

--- a/ui/components/common/LearnMore.js
+++ b/ui/components/common/LearnMore.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { wrapper } from "./LearnMore.css";
+
+const LearnMore = ({
+    url = "https://docs.aerogear.org/aerogear/latest/data-sync#",
+    fragment = "",
+    text = "Learn More"
+}) => (
+    <span className={wrapper}>
+        <a href={`${url}${fragment}`}>
+            {text}<span className="fa fa-external-link" />
+        </a>
+    </span>
+);
+
+export { LearnMore };

--- a/ui/components/common/common.css
+++ b/ui/components/common/common.css
@@ -1,8 +1,3 @@
-.learnMore {
-    font-size: 9px;
-    color: #4EABDA;
-}
-
 .flexWrapper {
     /* 206 being the exact height of the components on top of SchemaContainer */
     height: calc(100vh - 210px) !important;

--- a/ui/components/common/defaultEmptyView.css
+++ b/ui/components/common/defaultEmptyView.css
@@ -8,7 +8,3 @@
 .emptyTitle {
     font-size: 17px;
 }
-
-.learnMore {
-    composes: learnMore from "./common.css";
-}

--- a/ui/components/common/index.js
+++ b/ui/components/common/index.js
@@ -2,3 +2,5 @@ export * from "./CommonToolbar";
 export * from "./CodeEditor";
 export * from "../../helper/Validators";
 export * from "./ResolversCount";
+export * from "./DefaultEmptyView";
+export * from "./LearnMore";

--- a/ui/components/data-sources/EmptyList.js
+++ b/ui/components/data-sources/EmptyList.js
@@ -21,7 +21,7 @@ const EmptyList = ({ action, title, info, actionName }) => (
             {info}
         </EmptyStateInfo>
         <EmptyStateHelp>
-            For more information have a look at the <a href="https://docs.aerogear.org">&nbsp;docs</a>
+            For more information have a look at the <a href="https://docs.aerogear.org/aerogear/latest/data-sync">&nbsp;docs</a>
         </EmptyStateHelp>
         <EmptyStateAction>
             <Button

--- a/ui/components/resolvers/CustomTypeResolversList.js
+++ b/ui/components/resolvers/CustomTypeResolversList.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { ListView } from "patternfly-react";
 import { CustomTypeResolversListItem } from "./resolvers-list-item";
+import { LearnMore } from "../common";
 
 import styles from "./ResolversListItem.css";
-import { learnMore } from "../common/common.css";
 
 /**
  * A CustomTypeItem is used to render a user defined GraphQL type in the resolver tab's
@@ -16,10 +16,8 @@ const CustomTypeResolversList = props => {
         <div className={resolversContent}>
             <div className={resolversHeader}>
                 <div className={resolversHeaderName}>
-                    <span style={{ marginRight: "12px" }}>{text}</span>
-                    <span className={learnMore}>
-                        <a href="https://www.google.es">Learn More <span className="fa fa-external-link" /></a>
-                    </span>
+                    <span>{text}</span>
+                    <LearnMore fragment="structure-view-2" />
                 </div>
             </div>
             <ListView className={resolversList}>

--- a/ui/components/resolvers/GenericTypeResolversList.js
+++ b/ui/components/resolvers/GenericTypeResolversList.js
@@ -2,10 +2,9 @@ import React from "react";
 import { Query } from "react-apollo";
 import { Spinner, ListView } from "patternfly-react";
 import { GenericTypeResolversListItem } from "./resolvers-list-item";
-import { ResolversCount } from "../common";
+import { ResolversCount, LearnMore } from "../common";
 
 import styles from "./ResolversListItem.css";
-import { learnMore } from "../common/common.css";
 
 import GetResolvers from "../../graphql/GetResolvers.graphql";
 
@@ -56,10 +55,8 @@ const GenericTypeResolversList = ({ schemaId, items, text, kind, onClick }) => {
                     <div className={resolversContent}>
                         <div className={resolversHeader}>
                             <div className={resolversHeaderName}>
-                                <span style={{ marginRight: "12px" }}>{text}</span>
-                                <span className={learnMore}>
-                                    <a href="https://www.google.es">Learn More <span className="fa fa-external-link" /></a>
-                                </span>
+                                <span>{text}</span>
+                                <LearnMore fragment="structure-view-2" />
                             </div>
                             {kind !== "subscription" ? <ResolversCount fields={fields} resolvers={data.resolvers} /> : null}
                         </div>

--- a/ui/components/resolvers/ResolverDetail.css
+++ b/ui/components/resolvers/ResolverDetail.css
@@ -40,10 +40,6 @@
     float: right;
 }
 
-.learnMore {
-    composes: learnMore from "../common/common.css";
-}
-
 .formContainer {
     padding-left: 35px;
     padding-top: 10px;

--- a/ui/components/resolvers/ResolverDetail.js
+++ b/ui/components/resolvers/ResolverDetail.js
@@ -17,7 +17,7 @@ import { SubscriptionsDropDown } from "./SubscriptionsDropDown";
 import { MappingTemplateDropDown } from "./MappingTemplateDropDown";
 import { HookFormGroup } from "./HookFormGroup";
 import { DeleteResolverDialog } from "./DeleteResolverDialog";
-import { DefaultEmptyView } from "../common/DefaultEmptyView";
+import { LearnMore, DefaultEmptyView } from "../common";
 
 import UpsertResolver from "../../graphql/UpsertResolver.graphql";
 import GetDataSources from "../../graphql/GetDataSources.graphql";
@@ -27,7 +27,7 @@ import GetResolvers from "../../graphql/GetResolvers.graphql";
 import { getTemplatesForDataSource } from "./MappingTemplates";
 
 import {
-    detailHeader, detailFormsContainer, learnMore, detailFormsHeader, formContainer,
+    detailHeader, detailFormsContainer, detailFormsHeader, formContainer,
     detailFormGroup, detailButtonFooter, buttonSave, buttonDelete
 } from "./ResolverDetail.css";
 
@@ -214,9 +214,7 @@ class ResolverDetail extends Component {
                 <div className={detailFormsContainer}>
                     <h3 className={detailFormsHeader}>
                         <span style={{ marginRight: "12px" }}>Resolver</span>
-                        <span className={learnMore}>
-                            <a href="https://www.google.es">Learn More <span className="fa fa-external-link" /></a>
-                        </span>
+                        <LearnMore fragment="resolvers" />
                     </h3>
 
                     <Form horizontal className={formContainer}>

--- a/ui/components/resolvers/ResolversListItem.css
+++ b/ui/components/resolvers/ResolversListItem.css
@@ -12,6 +12,10 @@
     flex: 1;
 }
 
+.resolversHeaderName > span {
+    margin-right: 12px;
+}
+
 .resolversContent {
     padding-left: 20px;
     padding-right: 20px;

--- a/ui/components/schema/StructureView.js
+++ b/ui/components/schema/StructureView.js
@@ -49,7 +49,7 @@ const StructureView = props => {
         <DefaultEmptyView
             text="You must define a Schema for data sync to work correctly"
             infoText="Schema Reference"
-            infoURL="https://graphql.org/learn/schema/"
+            infoURL="https://docs.aerogear.org/aerogear/latest/data-sync#schema"
         />
     );
 };


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-7856

## What
Extracts a new component wrapping the "Lean More" links, and changes all urls to point to data-sync docs.

## Why
Because it had to be done.

## How
Gracefully.

## Verification Steps
Next links may be verified (although the data-sync docs are not yet available at this point):

- Empty DataSources screen
- Empty Schema's StructureView (right side component)
- ResolversList headers (Query, Mutation, etc)
- ResolverDetail header

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
 

