### PR TITLE
List items should expand when clicking on the arrow only

### DIFF
--- a/ui/components/resolvers/DataSourcesDropDown.js
+++ b/ui/components/resolvers/DataSourcesDropDown.js
@@ -20,9 +20,9 @@ const DataSourcesDropDown = ({ selected, onDataSourceSelect }) => {
             <Col sm={2} className={dataSourceControlLabel}>Data Source</Col>
             <Col sm={6}>
                 <Query query={GetDataSources} variables={filter}>
-                    {({ loading, error, data: { dataSources } }) => {
+                    {({ loading, error, data: { dataSources } = {} }) => {
                         const disableDropdown = loading
-                            || error
+                            || typeof error === "object"
                             || !dataSources;
 
                         const options = dataSources

--- a/ui/components/resolvers/resolvers-list-item/AdditionalInfo.js
+++ b/ui/components/resolvers/resolvers-list-item/AdditionalInfo.js
@@ -13,16 +13,22 @@ class AdditionalInfo extends Component {
         }
     }
 
-    render() {
+    onResolverClick(clickEvent) {
         const { resolver, onClick, schemaId, type, field } = this.props;
+        clickEvent.stopPropagation();
+        onClick({ schemaId, type, field, ...resolver });
+    }
+
+    render() {
+        const { resolver, field } = this.props;
 
         return (
             <div className={resolver ? headingResolverSet : headingResolverUnset}>
                 <span
                     role="button"
                     tabIndex={0}
-                    onClick={() => onClick({ schemaId, type, field, ...resolver })}
-                    onKeyDown={() => onClick({ schemaId, type, field, ...resolver })}
+                    onClick={e => this.onResolverClick(e)}
+                    onKeyDown={e => this.onResolverClick(e)}
                     key={field}
                 >{resolver ? resolver.DataSource.name : "no resolver set"}
                 </span>


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-7756

## What
Prevents ResolversList items from expanding when clicking on the resolver button

## Why
It's annoying.

## How
Intercept onClick and stop propagation avoiding Patternfly default behaviour

## Verification Steps

1. Having a Schame defined, go to Resolvers and click on the resolver button of some items. The item should not expand.
2. Click anywhere on the item BUT the button, the item should expand/collapse.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
 

