### PR TITLE
Prevent selecting same resolver twice

### DIFF
--- a/ui/components/resolvers/ResolversContainer.js
+++ b/ui/components/resolvers/ResolversContainer.js
@@ -25,13 +25,19 @@ class ResolversContainer extends Component {
         return [];
     }
 
-    onResolverClicked(resolver) {
-        const { isResolverSaved } = this.state;
+    onResolverClicked(clickedResolver) {
+        const { resolver, isResolverSaved } = this.state;
+
+        if (resolver !== null
+            && resolver.type === clickedResolver.type
+            && resolver.field === clickedResolver.field) {
+            return;
+        }
 
         if (isResolverSaved) {
-            this.setState({ resolver });
+            this.setState({ resolver: clickedResolver });
         } else {
-            this.setState({ showChangeConfirmation: true, clickedResolver: resolver });
+            this.setState({ showChangeConfirmation: true, clickedResolver });
         }
     }
 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-7834

## What
Checks if clicked resolver is the one already selected and if so do nothing

## Why
UX improvement

## How

## Verification Steps

1. Go to Resolvers, select any
2. Then do any change, so that the Save button is enabled
3. Without saving it, select the same resolver again: nothing should happen
4. Without saving it, select a different resolver: a warning should pop up

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 
 

