### PR TITLE
Fix blank screen after resolver is deleted

### DIFF
--- a/ui/components/resolvers/ResolverDetail.js
+++ b/ui/components/resolvers/ResolverDetail.js
@@ -190,6 +190,10 @@ class ResolverDetail extends Component {
     }
 
     onDeleteResolver() {
+        // Notify ResolversContainer, that there are no unsaved changes now
+        const { onResolverEdit } = this.props;
+        onResolverEdit({ isResolverSaved: true });
+
         this.setState(INITIAL_STATE);
     }
 

--- a/ui/components/resolvers/ResolversContainer.js
+++ b/ui/components/resolvers/ResolversContainer.js
@@ -28,7 +28,7 @@ class ResolversContainer extends Component {
     onResolverClicked(clickedResolver) {
         const { resolver, isResolverSaved } = this.state;
 
-        if (resolver !== null
+        if (resolver !== null && clickedResolver !== null
             && resolver.type === clickedResolver.type
             && resolver.field === clickedResolver.field) {
             return;


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-7901
When user removes resolver, blank screen is displayed. User needs to reload the page.
Plus there was an issue when user tries to delete resolver with unsaved changes.

## How

Check if `clickedResolver` is not null.
Plus when deleting resolver notify `ResolversContainer` that there are no unsaved changes.

## Verification Steps

1. try to delete resolver - you should not see blank screen.
2. try to delete resolver with unsaved changes - you should not see warning about unsaved resolver.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

